### PR TITLE
Remove duplicated title

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,8 +50,6 @@ POST /api/v1/recommendations/?token=12345678901234567890123456789012
 ```
 #### Query Parameters
 
-#### Query Parameters
-
 | Parâmetro | Tipo | Descrição |
 | :--- | :--- | :--- |
 | `token` | `string` | **Obrigatório**. Sua Woliver API token |


### PR DESCRIPTION
## Problema que este PR resolve
Remove título `Query Parameter` duplicado na seção de recomendações.
## Mais detalhes da solução
