### PR TITLE
fix/recommendation-url

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ POST /api/v1/recommendations/?token=12345678901234567890123456789012
 
 ```javascript
 {
-  "url": "https://example.woliver.net/recomendacoes/k28Jv5#STAFF/"
+  "url": "https://example.woliver.net/recomendacoes/k28Jv5?staff_hash=STAFF"
 }
 ```
 
@@ -140,7 +140,7 @@ POST /api/v1/listings/{listing_id}/recommend/?token=1234567890123456789012345678
 
 ```javascript
 {
-  "url": "https://example.woliver.net/recomendacoes/k28Jv5/"
+  "url": "https://example.woliver.net/recomendacoes/k28Jv5?staff_hash=STAFF"
 }
 ```
 


### PR DESCRIPTION
## Problema que este PR resolve
Novo padrão para identificar hash do staff responsável pela recomendação
Ex.: `https://demo.woliver.net/recomendacoes/Lw4MnN?staff_hash=corretor_bob`

## Mais detalhes da solução
Padronização do uso de query parameters nas urls geradas pelo sistema